### PR TITLE
fix broken CI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mercator
 
-[![Circle CI](https://circleci.com/gh/LendingClub/mercator.svg?style=svg)](https://circleci.com/gh/LendingClub/mercator")
+[![Circle CI](https://circleci.com/gh/LendingClub/mercator.svg?style=svg)](https://circleci.com/gh/LendingClub/mercator)
 [![Download](https://api.bintray.com/packages/lendingclub/OSS/mercator/images/download.svg)](https://bintray.com/lendingclub/OSS/mercator/_latestVersion)
 
 


### PR DESCRIPTION
The circleci link on github landing page was 404.  
Just watched Ashley's talk at devopsdays chi.  Great stuff!  👍🏻 